### PR TITLE
fix: strip off local path in fileName

### DIFF
--- a/decrypt-ha-backup/__main__.py
+++ b/decrypt-ha-backup/__main__.py
@@ -121,14 +121,14 @@ class BackupItem:
         self._slug = slug
         self._name = name
         self._backup = backup
-        self._info = self._backup._tarfile.getmember(self.fileName)
+        self._info = self._backup._tarfile.getmember(os.path.basename(self.fileName))
         if not self._info:
             raise FailureError(f"Backup file doesn't contain a file for {self._name} with the name '{self.fileName}'")
 
     @property
     def fileName(self):
         ext = ".tar.gz" if self._backup.compressed else ".tar"
-        return f"./{self._slug.replace('/', '_')}{ext}"
+        return f"{self._slug.replace('/', '_')}{ext}"
 
     @property
     def slug(self):


### PR DESCRIPTION
In my case it fixed this: https://github.com/sabeechen/decrypt-ha-backup/issues/1.

Apparently the self.filename variable contains a local path (e.g. ./homeassistant.tar.gz) which causes issues when looking for this member in the tar file (which contains just filenames (e.g. homeassistant.tar.gz).

I have NOT tested it in other OSs